### PR TITLE
Avoid Special Characters in Identifiers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -116,7 +116,7 @@ rules:
         - single
     id-match:
         - 2
-        - ^[a-zA-Z$]+$
+        - ^[a-zA-Z]+$
     semi-spacing: 2
     semi: 2
     space-after-keywords: 2

--- a/web-app/js/source/syllabus.js
+++ b/web-app/js/source/syllabus.js
@@ -16,22 +16,22 @@ $(function () {
 	});
 });
 
-function toggleVisibility ($toggle, $target) {
+function toggleVisibility (toggle, target) {
 	'use strict';
 
-	if ($toggle.is(':checked')) {
-		$target.show();
+	if (toggle.is(':checked')) {
+		target.show();
 	} else {
-		$target.hide();
+		target.hide();
 	}
 }
 
-function togglePrintView ($toggle) {
+function togglePrintView (toggle) {
 	'use strict';
 
-	if ($toggle.is(':checked')) {
-		$toggle.hide();
+	if (toggle.is(':checked')) {
+		toggle.hide();
 	} else {
-		$toggle.parent().hide();
+		toggle.parent().hide();
 	}
 }


### PR DESCRIPTION
`$` prefixed identifiers are traditionally reserved for private or custom Jquery methods.
The goal of the `id-match` rule that is currently set is to avoid usage of special characters and numbers in variable names. (these can tend to make code harder to read)