### PR TITLE
Update ESLint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -23,6 +23,7 @@ rules:
     guard-for-in: 2
     no-alert: 2
     no-caller: 2
+    no-case-declarations: 2
     no-else-return: 2
     no-empty-pattern: 2
     no-eq-null: 2

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "url": "https://github.com/IMOD-ASU/imod"
   },
   "devDependencies": {
-    "bower": "^1.6.3",
+    "bower": "^1.6.6",
     "csscomb": "^3.1.8",
-    "eslint": "^1.8.0"
+    "eslint": "^1.10.1"
   }
 }


### PR DESCRIPTION
renames `.eslintrc` to `.eslintrc.yml`
adds new `no-case-declarations` lint rule

**NOTE**
Linter will not correctly pickup the `.eslintrc.yml` file unless it is running `ESLint` version 1.10.0 or higher, not updating will result in a lot of false positives on lint checks.
To update run:
```
npm install --global eslint
```