### PR TITLE
Explicit Global Variables

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -69,7 +69,7 @@ rules:
     no-shadow: 1
     no-undefined: 2
     no-use-before-define:
-        - 1
+        - 2
         - nofunc
     # Stylistic Issues
     array-bracket-spacing:

--- a/web-app/js/source/application.js
+++ b/web-app/js/source/application.js
@@ -1,4 +1,3 @@
-var cleanForm;
 var formSubmitted = false;
 
 $(document).ready(function () {
@@ -133,9 +132,9 @@ $(document).ready(function () {
 window.onload = function () {
 	'use strict';
 	if ($('#contentTable').length) {
-		cleanForm = $('form, #contentTable').find('select, textarea, input').serialize();
+		window.cleanForm = $('form, #contentTable').find('select, textarea, input').serialize();
 	} else {
-		cleanForm = $('form').find('select, textarea, input').serialize();
+		window.cleanForm = $('form').find('select, textarea, input').serialize();
 	}
 };
 
@@ -149,9 +148,8 @@ window.onbeforeunload = function () {
 		dirtyForm = $('form').find('select, textarea, input').serialize();
 	}
 
-	if (!formSubmitted && cleanForm !== dirtyForm) {
+	if (!formSubmitted && window.cleanForm !== dirtyForm) {
 		return 'You have unsaved changes. Please save them before proceeding.';
 	}
 	return null;
 };
-

--- a/web-app/js/source/assessment.js
+++ b/web-app/js/source/assessment.js
@@ -1,7 +1,6 @@
 var baseUrl = window.location.pathname.match(/\/[^\/]+\//)[0];
 var isTopLeftClicked = 1;
 var isTopRightClicked = 1;
-var cleanForm = cleanForm;
 
 /**
  * Opens the modal to create a new assessment technique
@@ -186,7 +185,7 @@ function displayAssessmentInformationInEdit (isClone) {
 	})
 	.done(function (data) {
 		populateAssessmentTechnique(data, isClone);
-		cleanForm = $('form').find('select, textarea, input').serialize();
+		window.cleanForm = $('form').find('select, textarea, input').serialize();
 	});
 }
 function showAssessmentTechnique () {

--- a/web-app/js/source/pedagogy.js
+++ b/web-app/js/source/pedagogy.js
@@ -1,5 +1,4 @@
 var baseUrl = window.location.pathname.match(/\/[^\/]+\//)[0];
-var cleanForm = cleanForm;
 
 /**
  * Opens the modal to create a new pedagogy technique
@@ -189,7 +188,7 @@ function displayPedagogyInformationInEdit () {
 	})
 	.done(function (data) {
 		populatePedagogyTechnique(data);
-		cleanForm = $('form').find('select, textarea, input').serialize();
+		window.cleanForm = $('form').find('select, textarea, input').serialize();
 	});
 }
 


### PR DESCRIPTION
* Use global `window` object to declare global variable
* Re-enable `no-use-before-define` rule